### PR TITLE
Miscellaneous Postgresql Fixes to Formula, gunicorn Worker Timeout by Default

### DIFF
--- a/alcali/defaults.yaml
+++ b/alcali/defaults.yaml
@@ -15,6 +15,7 @@ alcali:
     host: '0.0.0.0'
     port: 5000
     workers: {{ grains['num_cpus'] }}
+    worker_timeout: 300
   # All the items under this section will be converted into an environment file.
   config:
     db_backend: mysql

--- a/alcali/files/alcali.service.jinja
+++ b/alcali/files/alcali.service.jinja
@@ -7,7 +7,7 @@ EnvironmentFile={{ directory }}/.env
 SyslogIdentifier={{ service }}
 User={{ user }}
 Group={{ group }}
-ExecStart={{ directory }}/.venv/bin/gunicorn {{ name }} --bind {{ host }}:{{ port }} -w {{ workers }}
+ExecStart={{ directory }}/.venv/bin/gunicorn {{ name }} --bind {{ host }}:{{ port }} -w {{ workers }} -t {{ worker_timeout }}
 WorkingDirectory={{ directory }}/code
 Restart=always
 

--- a/alcali/package/install.sls
+++ b/alcali/package/install.sls
@@ -12,7 +12,7 @@
     'Arch': ['mariadb-libs'],
     'Debian': ['default-libmysqlclient-dev', 'python3-dev'],
 }.get(grains.os_family) %}
-{% elif alcali.config.db_backend == 'postgres' %}
+{% elif alcali.config.db_backend == 'postgresql' %}
 {% set db_connector = 'psycopg2' %}
 {% set db_requirements = {
     'RedHat': ['libpq-devel', 'python3-devel'],

--- a/alcali/service/running.sls
+++ b/alcali/service/running.sls
@@ -21,6 +21,7 @@ alcali-file-managed-service-running:
         host: {{ alcali.gunicorn.host }}
         port: {{ alcali.gunicorn.port }}
         workers: {{ alcali.gunicorn.workers }}
+        worker_timeout: {{ alcali.gunicorn.worker_timeout }}
     - source: salt://alcali/files/alcali.service.jinja
     - template: jinja
   module.run:

--- a/pillar.example
+++ b/pillar.example
@@ -15,6 +15,7 @@ alcali:
     host: '0.0.0.0'
     port: 5000
     workers: {{ grains['num_cpus'] }}
+    worker_timeout: 300 # Set higher if you see frequent "WORKER TIMEOUT" errors when refreshing minions
   # All the items under this section will be converted into an environment file.
   config:
     db_backend: mysql


### PR DESCRIPTION
Hi!

Loving alcali so far and appreciate you open-sourcing this! We're using a postgres backend and ran into a few minor issues with the formula. Also frequently ran into worker timeouts when refreshing our 200 or so minions in this environment. Thoughts on this PR?

- Changing db_backend for PGSQL from postgres->postgresql to match the name of the Django DB backend name
- Setting a higher default gunicorn worker timeout. Seeing the 30s default get hit regularly when using only 200 or so minions
- Adding worker_timeout to systemd unit

```
Jun 25 13:54:37 svlchi6dsalt1 alcali[12269]: django.core.exceptions.ImproperlyConfigured: 'django.db.backends.postgres' isn't an available database backend.
Jun 25 13:54:37 svlchi6dsalt1 alcali[12269]: Try using 'django.db.backends.XXX', where XXX is one of:
Jun 25 13:54:37 svlchi6dsalt1 alcali[12269]:     'mysql', 'oracle', 'postgresql', 'sqlite3'
```